### PR TITLE
fixed issue with latin encoding

### DIFF
--- a/personalize_sample_notebook.ipynb
+++ b/personalize_sample_notebook.ipynb
@@ -1104,7 +1104,7 @@
     }
    ],
    "source": [
-    "items = pd.read_csv('./ml-100k/u.item', sep='|', usecols=[0,1], header=None)\n",
+    "items = pd.read_csv('./ml-100k/u.item', sep='|', usecols=[0,1], encoding='latin-1')\n",
     "items.columns = ['ITEM_ID', 'TITLE']\n",
     "\n",
     "user_id, item_id, _ = data.sample().values[0]\n",
@@ -1177,9 +1177,9 @@
  ],
  "metadata": {
   "kernelspec": {
-   "display_name": "Python 3",
+   "display_name": "conda_python3",
    "language": "python",
-   "name": "python3"
+   "name": "conda_python3"
   },
   "language_info": {
    "codemirror_mode": {
@@ -1191,9 +1191,9 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.7.2"
+   "version": "3.6.5"
   }
  },
  "nbformat": 4,
- "nbformat_minor": 2
+ "nbformat_minor": 4
 }


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*
The sample notebook had an issue where it didn't work due to not specifying the encoding used for the item metadata used to render movie titles. This has been corrected.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.