### PR TITLE
Added 3 interactions and cleanup instructions

### DIFF
--- a/getting_started/ReInvent2019_Workshop.ipynb
+++ b/getting_started/ReInvent2019_Workshop.ipynb
@@ -944,7 +944,7 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "The cell below will execute interactions and update the dataframe with the results so you can see the overall impact. Feel free to run the cell several times with movie IDs less than 1000. Note for this demo it will error if you use the same movie twice, this is due to how we showcase the headers."
+    "The 3 cells below will simulate adding a movie ot the dataset and then rendering the results after each interaction. The first column is the original recommendations, the subsequent columns are for each movie that your user has now interacted with. The column header is the name of the movie that the user interacted with, and you can then see how the recommendations are altered."
    ]
   },
   {
@@ -954,6 +954,28 @@
    "outputs": [],
    "source": [
     "movie_to_click = 180\n",
+    "recommendations_df = get_new_recommendations_df(recommendations_df, movie_to_click)\n",
+    "recommendations_df"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "movie_to_click = 210\n",
+    "recommendations_df = get_new_recommendations_df(recommendations_df, movie_to_click)\n",
+    "recommendations_df"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "movie_to_click = 415\n",
     "recommendations_df = get_new_recommendations_df(recommendations_df, movie_to_click)\n",
     "recommendations_df"
    ]
@@ -1146,6 +1168,140 @@
    "metadata": {},
    "source": [
     "In the cell above you can see the various recommendations for the users provided, in a real scenario the list of users could be your entire userbase allowing you to quickly reference and compare results between them."
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## Extra Bonus: Cleanup\n",
+    "\n",
+    "The cells below are totally optional if you are using Event Engine as your account is deleted after the workshop. If you'd like to use this in your own account later, the cells below will delete the resources created to prevent continous charges."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# Delete the campaign:\n",
+    "personalize.delete_campaign(campaignArn=campaign_arn)\n",
+    "time.sleep(60)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# Delete the solution\n",
+    "personalize.delete_solution(solutionArn=solution_arn)\n",
+    "time.sleep(60)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# Delete the event tracker\n",
+    "personalize.delete_event_tracker(eventTrackerArn=event_tracker_arn)\n",
+    "time.sleep(60)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# Delete the interaction dataset\n",
+    "personalize.delete_dataset(datasetArn=dataset_arn)\n",
+    "time.sleep(60)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# Delete the event dataset\n",
+    "event_interactions_dataset_arn = dataset_arn\n",
+    "event_interactions_dataset_arn = event_interactions_dataset_arn.replace(\"INTERACTIONS\", \"EVENT_INTERACTIONS\")\n",
+    "personalize.delete_dataset(datasetArn=event_interactions_dataset_arn)\n",
+    "time.sleep(60)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# Delete the schema\n",
+    "personalize.delete_schema(schemaArn=schema_arn)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# Delete the Dataset Group\n",
+    "personalize.delete_dataset_group(datasetGroupArn=dataset_group_arn)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# Empty the S3 Bucket\n",
+    "s3 = boto3.resource('s3')\n",
+    "bucket = s3.Bucket(bucket_name)\n",
+    "bucket.objects.all().delete()\n",
+    "time.sleep(60)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# Delete the S3 Bucket\n",
+    "bucket.delete()"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# IAM policies should also be removed\n",
+    "iam = boto3.client(\"iam\")\n",
+    "iam.detach_role_policy(PolicyArn=\"arn:aws:iam::aws:policy/AmazonS3FullAccess\", RoleName=role_name)\n",
+    "iam.detach_role_policy(PolicyArn=\"arn:aws:iam::aws:policy/service-role/AmazonPersonalizeFullAccess\",RoleName=role_name)\n",
+    "\n",
+    "iam.delete_role(RoleName=role_name)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## Last Step\n",
+    "\n",
+    "After cleaning up all of the resources you can now close this window and go back to the github page you stareted on. At the bottom of the Readme file are steps to delete the CloudFormation stack you created earlier. Once that is done you are 100% done with the workshop.\n",
+    "\n",
+    "Congratulations!"
    ]
   },
   {


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*
More feedback discovered people could be scared of altering some cells so interactions are now explicit for 3 movies. Also people wanted to re-use this outside of event engine so optional cleanup steps were added to the bottom. Cleanup addresses everything but the bulk-export name as that is not alterable at this time.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
