### PR TITLE
fixed config issue with wrong API call

### DIFF
--- a/getting_started/lambda_examples/Sending_Events_to_S3.ipynb
+++ b/getting_started/lambda_examples/Sending_Events_to_S3.ipynb
@@ -165,7 +165,7 @@
     "    trackingId = \"a68baf70-f0f2-4c66-af2d-e11047a0372f\"\n",
     "    print(content[0]['userId'])\n",
     "    \n",
-    "    personalize.put_events(\n",
+    "    personalize_events.put_events(\n",
     "        trackingId = trackingId,\n",
     "        userId = content[0]['userId'],\n",
     "        sessionId = content[0]['sessionId'],\n",


### PR DESCRIPTION
*Issue #, if available:* NA

*Description of changes:*

In the Lambda example we were not using the personalize_events API connection with boto, this has been corrected.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
