### PR TITLE
Fixed typo

### DIFF
--- a/getting_started/2.View_Campaign_And_Interactions.ipynb
+++ b/getting_started/2.View_Campaign_And_Interactions.ipynb
@@ -122,7 +122,7 @@
     "    Takes in an ID, returns a title\n",
     "    \"\"\"\n",
     "    movie_id = int(movie_id)\n",
-    "    return items.iloc[movie_id]['TITLE']"
+    "    return items.loc[movie_id]['TITLE']"
    ]
   },
   {


### PR DESCRIPTION
`ITEM_ID` starts from `1`, using `df.iloc` instead of `df.loc` produces off-by-one results.



By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
