### PR TITLE
Update "First Campaign" notebook to use user-personalization recipe

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,3 +3,4 @@ ml-100k
 .ipynb_checkpoints
 ml-1m
 json_input.*
+.DS_Store

--- a/getting_started/notebooks/1.Building_Your_First_Campaign.ipynb
+++ b/getting_started/notebooks/1.Building_Your_First_Campaign.ipynb
@@ -8,7 +8,7 @@
     "\n",
     "This notebook will walk you through the steps to build a recommendation model for movies based on data collected from the movielens data set. The goal is to recommend movies that are relevant based on a particular user.\n",
     "\n",
-    "The data is coming from the MovieLens project, you can google it during any of the waiting periods to learn more about the data and potential uses."
+    "The data is coming from the MovieLens project, you can learn more about the data and potential uses by doing a web search during any of the waiting periods in the cells below."
    ]
   },
   {
@@ -31,7 +31,7 @@
    "source": [
     "## Imports \n",
     "\n",
-    "Python ships with a broad collection of libraries and we need to import those as well as the ones installed to help us like boto3(The AWS SDK) and Pandas/Numpy which are core data science tools"
+    "Python ships with a broad collection of libraries and we need to import those as well as the ones installed to help us like [boto3](https://aws.amazon.com/sdk-for-python/) (AWS SDK for python) and [Pandas](https://pandas.pydata.org/)/[Numpy](https://numpy.org/) which are core data science tools."
    ]
   },
   {
@@ -76,7 +76,8 @@
     "\n",
     "Below you will update the `bucket` variable to instead be set to the value that you created earlier in the CloudFormation steps, this should be in a text file from your earlier work. the `filename` does not need to be changed.\n",
     "\n",
-    "### Specify a Bucket and Data Output Location"
+    "### Specify a Bucket and Data Output Location\n",
+    "Be sure to update the `bucket` value if you customized it during deployment of the CloudFormation template. Click in the cell below to make changes."
    ]
   },
   {
@@ -85,7 +86,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "bucket = \"personalize-demo-cking\"       # replace with the name of your S3 bucket\n",
+    "bucket = \"personalizedemofirstnamelastname\"       # replace with the name of your S3 bucket\n",
     "filename = \"movie-lens-100k.csv\""
    ]
   },
@@ -126,11 +127,11 @@
     "\n",
     "As you can see the data contains a UserID, ItemID, Rating, and Timestamp.\n",
     "\n",
-    "We are now going to remove the items with low rankings, and remove that column before we build our model.\n",
+    "We are now going to remove the items with low rankings, and remove the Rating column before we build our model.\n",
     "\n",
     "Once done we will now save the file as a new CSV and then upload it to S3.\n",
     "\n",
-    "All of that is done by simply executing the lines below."
+    "All of that is done by executing the lines in the cell below."
    ]
   },
   {
@@ -470,7 +471,14 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "Here you can see below that we are picking the `HRNN` recipie."
+    "#### User Personalization\n",
+    "The [User-Personalization](https://docs.aws.amazon.com/personalize/latest/dg/native-recipe-new-item-USER_PERSONALIZATION.html) (aws-user-personalization) recipe is optimized for all USER_PERSONALIZATION recommendation scenarios. When recommending items, it uses automatic item exploration.\n",
+    "\n",
+    "With automatic exploration, Amazon Personalize automatically tests different item recommendations, learns from how users interact with these recommended items, and boosts recommendations for items that drive better engagement and conversion. This improves item discovery and engagement when you have a fast-changing catalog, or when new items, such as news articles or promotions, are more relevant to users when fresh.\n",
+    "\n",
+    "You can balance how much to explore (where items with less interactions data or relevance are recommended more frequently) against how much to exploit (where recommendations are based on what we know or relevance). Amazon Personalize automatically adjusts future recommendations based on implicit user feedback.\n",
+    "\n",
+    "First, select the recipe by finding the ARN in the list of recipes above."
    ]
   },
   {
@@ -479,7 +487,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "recipe_arn = \"arn:aws:personalize:::recipe/aws-hrnn\" # aws-hrnn selected for demo purposes"
+    "recipe_arn = \"arn:aws:personalize:::recipe/aws-user-personalization\" # aws-user-personalization selected for demo purposes"
    ]
   },
   {
@@ -505,7 +513,7 @@
    "outputs": [],
    "source": [
     "create_solution_response = personalize.create_solution(\n",
-    "    name = \"personalize-demo-soln-hrnn\",\n",
+    "    name = \"personalize-demo-soln-user-personalization\",\n",
     "    datasetGroupArn = dataset_group_arn,\n",
     "    recipeArn = recipe_arn\n",
     ")\n",
@@ -541,7 +549,7 @@
    "source": [
     "#### Wait for Solution Version to Have ACTIVE Status\n",
     "\n",
-    "This will take at least 20 minutes."
+    "This will take approximately 40-50 minutes."
    ]
   },
   {
@@ -570,7 +578,7 @@
    "source": [
     "#### Get Metrics of Solution Version\n",
     "\n",
-    "Now that your solution and version exists, you can obtain the metrics for it to judge its performance. These metrics are not particularly good as it is a demo set of data, but with larger more compelx datasets you should see improvements."
+    "Now that your solution and version exists, you can obtain the metrics for it to judge its performance. These metrics are not particularly good as it is a demo set of data, but with larger more complex datasets you should see improvements."
    ]
   },
   {
@@ -590,9 +598,31 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
+    "We recommend reading [the documentation](https://docs.aws.amazon.com/personalize/latest/dg/working-with-training-metrics.html) to understand the metrics, but we have also copied parts of the documentation below for convenience.\n",
+    "\n",
+    "You need to understand the following terms regarding evaluation in Personalize:\n",
+    "\n",
+    "- *Relevant recommendation* refers to a recommendation that matches a value in the testing data for the particular user.\n",
+    "- *Rank* refers to the position of a recommended item in the list of recommendations. Position 1 (the top of the list) is presumed to be the most relevant to the user.\n",
+    "- *Query* refers to the internal equivalent of a GetRecommendations call.\n",
+    "\n",
+    "The metrics produced by Personalize are:\n",
+    "\n",
+    "- coverage: The proportion of unique recommended items from all queries out of the total number of unique items in the training data (includes both the Items and Interactions datasets).\n",
+    "- mean_reciprocal_rank_at_25: The [mean of the reciprocal ranks](https://en.wikipedia.org/wiki/Mean_reciprocal_rank) of the first relevant recommendation out of the top 25 recommendations over all queries. This metric is appropriate if you're interested in the single highest ranked recommendation.\n",
+    "- normalized_discounted_cumulative_gain_at_K: Discounted gain assumes that recommendations lower on a list of recommendations are less relevant than higher recommendations. Therefore, each recommendation is discounted (given a lower weight) by a factor dependent on its position. To produce the [cumulative discounted gain](https://en.wikipedia.org/wiki/Discounted_cumulative_gain) (DCG) at K, each relevant discounted recommendation in the top K recommendations is summed together. The normalized discounted cumulative gain (NDCG) is the DCG divided by the ideal DCG such that NDCG is between 0 - 1. (The ideal DCG is where the top K recommendations are sorted by relevance.) Amazon Personalize uses a weighting factor of 1/log(1 + position), where the top of the list is position 1. This metric rewards relevant items that appear near the top of the list, because the top of a list usually draws more attention.\n",
+    "- precision_at_K: The number of relevant recommendations out of the top K recommendations divided by K. This metric rewards precise recommendation of the relevant items."
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
     "## Create and Wait for the Campaign\n",
     "\n",
-    "Now that you have a working solution version you will need to create a campaign to use it with your applications. A campaign is simply a hosted copy of your model. Again there will be a short wait so after executing you can take a quick break while the infrastructure is being provisioned."
+    "Now that you have a working solution version you will need to create a campaign to use it with your applications. A campaign is a hosted solution version; an endpoint which you can query for recommendations. Pricing is set by estimating throughput capacity (requests from users for personalization per second). When deploying a campaign, you set a minimum transactions per second (TPS) value (`minProvisionedTPS`). This service, like many within AWS, will automatically scale based on demand, but if latency is critical, you may want to provision ahead for larger demand. For this demo, the minimum throughput threshold is set to 1. For more information, see the [pricing](https://aws.amazon.com/personalize/pricing/) page.\n",
+    "\n",
+    "As mentioned above, the user-personalization recipe used for our solution supports automatic exploration of \"cold\" items. You can control how much exploration is performed when creating your campaign. The `itemExplorationConfig` data type supports `explorationWeight` and `explorationItemAgeCutOff` parameters. Exploration weight determines how frequently recommendations include items with less interactions data or relevance. The closer the value is to 1.0, the more exploration. At zero, no exploration occurs and recommendations are based on current data (relevance). Exploration item age cut-off determines items to be explored based on time frame since latest interaction. Provide the maximum item age, in days since the latest interaction, to define the scope of item exploration. The larger the value, the more items are considered during exploration. For our campaign below, we'll specify an exploration weight of 0.5."
    ]
   },
   {
@@ -611,7 +641,12 @@
     "create_campaign_response = personalize.create_campaign(\n",
     "    name = \"personalize-demo-camp\",\n",
     "    solutionVersionArn = solution_version_arn,\n",
-    "    minProvisionedTPS = 1\n",
+    "    minProvisionedTPS = 1,\n",
+    "    campaignConfig = {\n",
+    "        \"itemExplorationConfig\": {\n",
+    "            \"explorationWeight\": \"0.5\"\n",
+    "        }\n",
+    "    }\n",
     ")\n",
     "\n",
     "campaign_arn = create_campaign_response['campaignArn']\n",
@@ -622,7 +657,9 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "#### Wait for Campaign to Have ACTIVE Status"
+    "#### Wait for Campaign to Have ACTIVE Status\n",
+    "\n",
+    "This should take about 10 minutes."
    ]
   },
   {
@@ -831,17 +868,9 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 1,
+   "execution_count": null,
    "metadata": {},
-   "outputs": [
-    {
-     "name": "stderr",
-     "output_type": "stream",
-     "text": [
-      "UsageError: Unknown variable 'recommendations_df'\n"
-     ]
-    }
-   ],
+   "outputs": [],
    "source": [
     "%store recommendations_df"
    ]
@@ -854,6 +883,13 @@
    "source": [
     "%store user_id"
    ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": []
   }
  ],
  "metadata": {
@@ -872,7 +908,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.6.5"
+   "version": "3.6.10"
   }
  },
  "nbformat": 4,


### PR DESCRIPTION
*Description of changes:*

- Switched from the HRNN to user-personalization recipe.
- Added explanatory text (from POC) for the new recipe and the campaign config parameters that it supports.
- Added more explanatory text to the solution version offline metrics since it was thin.
- Minor change to .gitignore to ignore Mac DS_Store files.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
