### PR TITLE
Fix Amazon Personalize User Segmentation - Required Updates

### DIFF
--- a/next_steps/core_use_cases/user_segmentation/user_segmentation_example.ipynb
+++ b/next_steps/core_use_cases/user_segmentation/user_segmentation_example.ipynb
@@ -579,9 +579,9 @@
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "number of train users:226200\n",
-      "number of warm test users who have non-empty interaction in TRAIN:51254\n",
-      "number of total users in TEST:55612, removed 4358 cold users from TEST\n"
+      "number of train users:124803\n",
+      "number of warm test users who have non-empty interaction in TRAIN:2935\n",
+      "number of total users in TEST:3724, removed 789 cold users from TEST\n"
      ]
     }
    ],

--- a/next_steps/core_use_cases/user_segmentation/user_segmentation_example.ipynb
+++ b/next_steps/core_use_cases/user_segmentation/user_segmentation_example.ipynb
@@ -586,9 +586,11 @@
     }
    ],
    "source": [
-    "test_start_date  = [2018,2,1]\n",
+    "train_start_date = [2017,2,1]\n",
+    "train_start_date = dt.datetime(*train_start_date).timestamp()\n",
+    "test_start_date  = [2018,8,5]\n",
     "test_start  = dt.datetime(*test_start_date).timestamp()\n",
-    "train_df=events_df[events_df['TIMESTAMP']<test_start]\n",
+    "train_df=events_df[(events_df['TIMESTAMP']>=train_start_date) & (events_df['TIMESTAMP']<test_start)]\n",
     "test_df=events_df[events_df['TIMESTAMP']>=test_start]\n",
     "warm_user=set(train_df['USER_ID'].unique())&set(test_df['USER_ID'].unique())\n",
     "print('number of train users:{}'.format(len(train_df['USER_ID'].unique())))\n",

--- a/next_steps/core_use_cases/user_segmentation/user_segmentation_example.ipynb
+++ b/next_steps/core_use_cases/user_segmentation/user_segmentation_example.ipynb
@@ -112,8 +112,8 @@
     "!mkdir $data_dir\n",
     "\n",
     "!cd $data_dir && \\\n",
-    "    wget http://deepyeti.ucsd.edu/jianmo/amazon/categoryFiles/Grocery_and_Gourmet_Food.json.gz && \\\n",
-    "    wget http://deepyeti.ucsd.edu/jianmo/amazon/metaFiles2/meta_Grocery_and_Gourmet_Food.json.gz"
+    "    wget http://jmcauley.ucsd.edu/data/amazon_v2/categoryFiles/Grocery_and_Gourmet_Food.json.gz && \\\n",
+    "    wget http://jmcauley.ucsd.edu/data/amazon_v2/metaFiles2/meta_Grocery_and_Gourmet_Food.json.gz"
    ]
   },
   {

--- a/next_steps/core_use_cases/user_segmentation/user_segmentation_example.ipynb
+++ b/next_steps/core_use_cases/user_segmentation/user_segmentation_example.ipynb
@@ -623,17 +623,6 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 21,
-   "metadata": {},
-   "outputs": [],
-   "source": [
-    "# Copy personalize.normal.json to the same directly\n",
-    "# the file can be found from drive: https://drive.corp.amazon.com/documents/hydro@/personalize.normal.json\n",
-    "!aws configure add-model --service-model file://`pwd`/personalize.normal.json --service-name personalize"
-   ]
-  },
-  {
-   "cell_type": "code",
    "execution_count": 99,
    "metadata": {},
    "outputs": [],

--- a/next_steps/core_use_cases/user_segmentation/user_segmentation_example.ipynb
+++ b/next_steps/core_use_cases/user_segmentation/user_segmentation_example.ipynb
@@ -533,7 +533,7 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "In order to test the performance of the solutions we split the interactions data into a training set and a holdout test set. The Amazon PrimePantry dataset has approximately 18 years of interaction data from 2000-08-09 to 2018-10-05 with approximately 1.7 million interactions. To reduce training time and cost for this demo we filter out transactions before 2017-02-01. We holdout ~10% of the most recent interactions and train on the remaining ~90%. This results in a split where we use interactions from 2017-02-01 through 2018-08-05 to train the solution and we use the remaining 3 months of interactions to simulate future activity as ground truth."
+    "In order to test the performance of the solutions we split the interactions data into a training set and a holdout test set. The Amazon PrimePantry dataset has approximately 18 years of interaction data from 2000-08-09 to 2018-10-05 with approximately 1.7 million interactions. To reduce training time and cost for this demo we filter out transactions before 2017-02-01. We holdout ~10% of the most recent interactions and train on the remaining ~90%. This results in a split where we use interactions from 2017-02-01 through 2018-08-05 to train the solution and we use the remaining 2 months of interactions to simulate future activity as ground truth."
    ]
   },
   {

--- a/next_steps/core_use_cases/user_segmentation/user_segmentation_example.ipynb
+++ b/next_steps/core_use_cases/user_segmentation/user_segmentation_example.ipynb
@@ -533,7 +533,7 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "In order to test the performance of the solutions we split the interactions data into a training set and a holdout test set. The Amazon PrimePantry dataset has approximately 18 years of interaction data from 2000-08-09 to 2018-10-05 with approximately 1.7 million interactions. We holdout 5% of the most recent interactions and train on the remaining 95%. This results in a split where we use interactions from 2000-08-09 through 2018-02-01 to train the solution and we use the remaining 8 months of interactions to simulate future activity as ground truth."
+    "In order to test the performance of the solutions we split the interactions data into a training set and a holdout test set. The Amazon PrimePantry dataset has approximately 18 years of interaction data from 2000-08-09 to 2018-10-05 with approximately 1.7 million interactions. To reduce training time and cost for this demo we filter out transactions before 2017-02-01. We holdout ~10% of the most recent interactions and train on the remaining ~90%. This results in a split where we use interactions from 2017-02-01 through 2018-08-05 to train the solution and we use the remaining 3 months of interactions to simulate future activity as ground truth."
    ]
   },
   {

--- a/next_steps/core_use_cases/user_segmentation/user_segmentation_example.ipynb
+++ b/next_steps/core_use_cases/user_segmentation/user_segmentation_example.ipynb
@@ -461,7 +461,16 @@
     }
    ],
    "source": [
-    "events_df = pd.read_json(data_dir + '/Grocery_and_Gourmet_Food.json.gz', lines=True, compression='infer')\n",
+    "# Read JSON into chunked list of DataFrames then join at end to prevent Kernel Death due to memory overload\n",
+    "\n",
+    "chunksize = 1000\n",
+    "\n",
+    "list_of_dataframes = []\n",
+    "\n",
+    "for df in pd.read_json(data_dir + '/Grocery_and_Gourmet_Food.json.gz', lines=True, compression='infer', chunksize=chunksize):\n",
+    "    list_of_dataframes.append(df)\n",
+    "\n",
+    "events_df = pd.concat(list_of_dataframes)\n",
     "events_df = events_df[['reviewerID', 'asin', 'unixReviewTime']].rename(columns = {'reviewerID':'USER_ID', 'asin':'ITEM_ID', \n",
     "                              'unixReviewTime':'TIMESTAMP'})\n",
     "events_df.drop_duplicates(inplace=True)\n",


### PR DESCRIPTION
*Issue #, if available:*

https://github.com/aws-samples/amazon-personalize-samples/issues/147

*Description of changes:*

This PR proposes solutions to the following issues (as detailed in PR #147)

1. The current Prime Pantry dataset links are dead and must be updated to the latest links provided by UCSD.

2. In the first cell of the "Load review data and build interaction dataset" section, reading the JSON into a DataFrame reliably causes Kernel Panic (reproduced 3/3 times on an m5d.xlarge instance), believed to be due to overwhelming the memory available. One solution is to load the dataset into a list of chunked smaller DataFrames then concatenate them once the dataset is fully loaded.

3. The first cell of the "Get the Personalize API model Json and Personalize Boto3 Client" section references the downloading of a private Amazon internal file external users will not have access to that manually adds Personalize as an available service in the CLI and is not required or runnable. This must be removed.


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
