### PR TITLE
User Segmentation Demo - Reduce Training Time & Cost

### DIFF
--- a/next_steps/core_use_cases/user_segmentation/user_segmentation_example.ipynb
+++ b/next_steps/core_use_cases/user_segmentation/user_segmentation_example.ipynb
@@ -533,7 +533,7 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "In order to test the performance of the solutions we split the interactions data into a training set and a holdout test set. The Amazon PrimePantry dataset has approximately 18 years of interaction data from 2000-08-09 to 2018-10-05 with approximately 1.7 million interactions. To reduce training time and cost for this demo we filter out transactions before 2017-02-01. We holdout ~10% of the most recent interactions and train on the remaining ~90%. This results in a split where we use interactions from 2017-02-01 through 2018-08-05 to train the solution and we use the remaining 2 months of interactions to simulate future activity as ground truth."
+    "In order to test the performance of the solutions we split the interactions data into a training set and a holdout test set. The Amazon PrimePantry dataset has approximately 18 years of interaction data from 2000-08-09 to 2018-10-05 with approximately 1.7 million interactions. To reduce training time and cost for this demo we filter out transactions before 2018-05-05. We holdout ~10% of the most recent interactions and train on the remaining ~90%. This results in a split where we use interactions from 2018-05-05 through 2018-09-20 to train the solution and we use the remaining 15 days of interactions to simulate future activity as ground truth."
    ]
   },
   {

--- a/next_steps/core_use_cases/user_segmentation/user_segmentation_example.ipynb
+++ b/next_steps/core_use_cases/user_segmentation/user_segmentation_example.ipynb
@@ -586,9 +586,9 @@
     }
    ],
    "source": [
-    "train_start_date = [2017,2,1]\n",
+    "train_start_date = [2018,5,5]\n",
     "train_start_date = dt.datetime(*train_start_date).timestamp()\n",
-    "test_start_date  = [2018,8,5]\n",
+    "test_start_date  = [2018,9,20]\n",
     "test_start  = dt.datetime(*test_start_date).timestamp()\n",
     "train_df=events_df[(events_df['TIMESTAMP']>=train_start_date) & (events_df['TIMESTAMP']<test_start)]\n",
     "test_df=events_df[events_df['TIMESTAMP']>=test_start]\n",

--- a/next_steps/core_use_cases/user_segmentation/user_segmentation_example.ipynb
+++ b/next_steps/core_use_cases/user_segmentation/user_segmentation_example.ipynb
@@ -579,9 +579,9 @@
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "number of train users:124803\n",
-      "number of warm test users who have non-empty interaction in TRAIN:2935\n",
-      "number of total users in TEST:3724, removed 789 cold users from TEST\n"
+      "number of train users:26235\n",
+      "number of warm test users who have non-empty interaction in TRAIN:74\n",
+      "number of total users in TEST:235, removed 161 cold users from TEST\n"
      ]
     }
    ],


### PR DESCRIPTION
*Issue #, if available:* #149

*Description of changes:*
This PR proposes a solution to reduce the training dataset to ~1/6 of the current number of users in order to lower solution version training time and costs while retaining consistent performance metrics.


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
