### PR TITLE
Update CF to restrict actions for the SageMaker assumed role

### DIFF
--- a/next_steps/generative_ai/user_personalized_marketing_messaging_with_amazon_personalize_and_gen_ai/05_Clean_Up.ipynb
+++ b/next_steps/generative_ai/user_personalized_marketing_messaging_with_amazon_personalize_and_gen_ai/05_Clean_Up.ipynb
@@ -359,8 +359,7 @@
     "        # 7. Delete dataset group\n",
     "        _delete_dataset_group(dataset_group_arn)\n",
     "\n",
-    "        logger.info(f'Dataset group {dataset_group_arn} fully deleted')\n",
-    "\n"
+    "        logger.info(f'Dataset group {dataset_group_arn} fully deleted')\n"
    ]
   },
   {
@@ -376,88 +375,14 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "## Clean up the S3 bucket and IAM role\n",
-    "\n",
-    "Start by deleting the role, then empty the bucket, then delete the bucket."
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "metadata": {},
-   "outputs": [],
-   "source": [
-    "iam = boto3.client('iam')"
+    "## Delete the Amazon S3 bucket and deployed stack"
    ]
   },
   {
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "Identify the name of the role you want to delete.\n",
-    "\n",
-    "You cannot delete an IAM role which still has policies attached to it. So after you have identified the relevant role, let's list the attached policies of that role."
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "metadata": {},
-   "outputs": [],
-   "source": [
-    "attached_policies = iam.list_attached_role_policies( RoleName = role_name)\n",
-    "print (attached_policies)\n",
-    "\n",
-    "# detaching the role policies\n",
-    "for attached_policy in attached_policies['AttachedPolicies']:\n",
-    "    iam.detach_role_policy(\n",
-    "        RoleName = role_name,\n",
-    "        PolicyArn = attached_policy['PolicyArn']\n",
-    "    )"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "metadata": {},
-   "outputs": [],
-   "source": [
-    "# removing the inline policies\n",
-    "in_line_policies = iam.list_role_policies(\n",
-    "    RoleName = role_name\n",
-    ")\n",
-    "print (in_line_policies)\n",
-    "\n",
-    "for in_line_policy in in_line_policies['PolicyNames']:\n",
-    "    iam.delete_role_policy(\n",
-    "    RoleName = role_name,\n",
-    "    PolicyName = in_line_policy\n",
-    ")"
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "metadata": {},
-   "source": [
-    "Finally, you should be able to delete the IAM role."
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "metadata": {},
-   "outputs": [],
-   "source": [
-    "iam.delete_role(\n",
-    "    RoleName = role_name\n",
-    ")"
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "metadata": {},
-   "source": [
-    "To delete an S3 bucket, it first needs to be empty. The easiest way to delete an S3 bucket, is just to navigate to S3 in the AWS console, delete the objects in the bucket, and then delete the S3 bucket itself."
+    "To delete an Amazon S3 bucket, it first needs to be empty. The easiest way to delete an S3 bucket, is just to navigate to S3 in the AWS console, delete the objects in the bucket, and then delete the S3 bucket itself."
    ]
   },
   {
@@ -491,7 +416,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.10.13"
+   "version": "3.10.15"
   }
  },
  "nbformat": 4,

--- a/next_steps/generative_ai/user_personalized_marketing_messaging_with_amazon_personalize_and_gen_ai/personalizeSimpleCFMarketingContentGen.yaml
+++ b/next_steps/generative_ai/user_personalized_marketing_messaging_with_amazon_personalize_and_gen_ai/personalizeSimpleCFMarketingContentGen.yaml
@@ -232,7 +232,10 @@ Resources:
             -
               Effect: Allow
               Action:
-                - "s3:*"
+                - "s3:ListBucket"
+                - "s3:GetObject*"
+                - "s3:ListBucket" 
+                - "s3:GetBucketPolicy"
               Resource:
                 - !Sub arn:aws:s3:::${S3Bucket}
                 - !Sub arn:aws:s3:::${S3Bucket}/*
@@ -246,7 +249,8 @@ Resources:
             - 
               Effect: Allow
               Action:
-                - "bedrock:*"
+                - "bedrock:InvokeModel"
+                - "bedrock:InvokeModelWithResponseStream"
               Resource:
                 - "*"
         Roles: 


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*
Update CF to restrict actions for the SageMaker assumed role
Updated cleanup notebook to use the CF rollback stack instead of unnecessary manual cleanup

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
